### PR TITLE
ugly hotfix for not breaking mapbox styles without names

### DIFF
--- a/packages/styles/src/index.js
+++ b/packages/styles/src/index.js
@@ -101,7 +101,6 @@ export default class StylesControl {
 		this.map.on('styledata', () => {
 			if (!this.map) throw Error('map is undefined');
 			const styleName = this.map.getStyle().name;
-			if (!styleName) throw Error('style must have name');
 			select.value = styleName;
 		});
 	}


### PR DESCRIPTION
When starting the map with one of the available styles (eg: 'mapbox://styles/mapbox/standard'), no name is added to the root style element. This makes the plugin crash.

My proposed fix is for sure not the most elegant, but it will keep the plugin from breaking for now.